### PR TITLE
Solution for failure to install MySQL-python

### DIFF
--- a/getting-started/installation/mac.md
+++ b/getting-started/installation/mac.md
@@ -45,6 +45,12 @@ _Note: you might get an error saying that _`libjpeg`_ is required. You can insta
 brew install libjpeg zlib
 ```
 
+_Note: if `mySQL-python` fails to install, you might be missing some of Apple's Command Line Tools. Install [Xcode](https://itunes.apple.com/ca/app/xcode/id497799835?mt=12) from the Mac App Store, then:_
+
+```bash
+xcode-select --install
+```
+
 ### Project settings
 
 Copy the sample settings file into the project root:


### PR DESCRIPTION
Provided solution for cases where ``MySQL-python`` doesn't install (with ``requirements.txt`` or by itself with ``pip``).